### PR TITLE
Fixing package publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+build/
 cache
 out
 dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nouns-protocol",
-  "version": "0.1.3",
+  "version": "0.1.5",
   "private": false,
   "repository": {
     "type": "git",
@@ -14,6 +14,7 @@
   "dependencies": {
     "@openzeppelin/contracts": "^4.7.0",
     "@openzeppelin/contracts-upgradeable": "^4.7.0",
+    "@types/node": "^18.6.2",
     "sol-uriencode": "^0.1.0",
     "sol2string": "https://github.com/mzhu25/sol2string.git#13f566f7dc61c820c24a673da72d0114183a17c8"
   },
@@ -34,10 +35,10 @@
     "*.sol": "solhint"
   },
   "scripts": {
-    "build": "forge build && yarn typechain",
+    "build": "forge build && yarn typechain && tsc",
     "clean": "forge clean && rm -rf ./dist",
-    "prepublishOnly": "rm -rf ./dist && forge clean && mkdir -p ./dist/artifacts && forge build && yarn typechain && cp -R src dist && cp -R addresses dist",
+    "prepublishOnly": "rm -rf ./dist && forge clean && mkdir -p ./dist/artifacts && yarn build && cp -R src dist && cp -R addresses dist",
     "test": "forge test",
-    "typechain": "typechain --target=ethers-v5 'dist/artifacts/*/*.json' --out-dir dist/typechain"
+    "typechain": "typechain --target=ethers-v5 'dist/artifacts/*/*.json' --out-dir build/typechain"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "./dist/typechain",
+    "target": "es2018",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true
+  },
+  "include": ["./build/typechain"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -389,6 +389,11 @@
     lodash "^4.17.15"
     ts-essentials "^7.0.1"
 
+"@types/node@^18.6.2":
+  version "18.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.2.tgz#ffc5f0f099d27887c8d9067b54e55090fcd54126"
+  integrity sha512-KcfkBq9H4PI6Vpu5B/KoPeuVDAbmi+2mDBqGPGUgoL7yXQtcWGu2vJWmmRkneWK3Rh0nIAX192Aa87AqKHYChQ==
+
 "@types/prettier@^2.1.1":
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.6.3.tgz#68ada76827b0010d0db071f739314fa429943d0a"


### PR DESCRIPTION
1. Updates the typechain build steps
2. Integrates typescript build to generate .js and .ts.d definition files as a proper package
3. bumps node package version to current version.