### PR TITLE
Do not transfer ownership on token fail mint

### DIFF
--- a/src/auction/IAuction.sol
+++ b/src/auction/IAuction.sol
@@ -83,6 +83,9 @@ interface IAuction is IUUPS, IOwnable, IPausable {
     /// @dev Thrown if the WETH contract throws a failure on transfer
     error FAILING_WETH_TRANSFER();
 
+    /// @dev Thrown if the auction creation failed
+    error AUCTION_CREATE_FAILED_TO_LAUNCH();
+
     ///                                                          ///
     ///                          FUNCTIONS                       ///
     ///                                                          ///

--- a/test/utils/mocks/MockPartialTokenImpl.sol
+++ b/test/utils/mocks/MockPartialTokenImpl.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.16;
+
+import {MockImpl} from "./MockImpl.sol";
+
+contract MockPartialTokenImpl is MockImpl {
+    function onFirstAuctionStarted() external {}
+}


### PR DESCRIPTION
1. Add regression test
2. Update unpause to not transfer ownership when `mint` fails.