### PR TITLE
Add getters for metadata renderer information

### DIFF
--- a/src/token/metadata/MetadataRenderer.sol
+++ b/src/token/metadata/MetadataRenderer.sol
@@ -99,7 +99,7 @@ contract MetadataRenderer is IPropertyIPFSMetadataRenderer, Initializable, UUPS,
     /// @notice The number of items in the IPFS data store
     /// @return ipfs data array size
     function ipfsDataCount() external view returns (uint256) {
-        return ipfsData.count;
+        return ipfsData.length;
     }
 
     /// @notice Updates the additional token properties associated with the metadata.

--- a/src/token/metadata/MetadataRenderer.sol
+++ b/src/token/metadata/MetadataRenderer.sol
@@ -84,14 +84,22 @@ contract MetadataRenderer is IPropertyIPFSMetadataRenderer, Initializable, UUPS,
     ///                                                          ///
 
     /// @notice The number of properties
+    /// @return properties array length
     function propertiesCount() external view returns (uint256) {
         return properties.length;
     }
 
     /// @notice The number of items in a property
     /// @param _propertyId The property id
+    /// @return items array length
     function itemsCount(uint256 _propertyId) external view returns (uint256) {
         return properties[_propertyId].items.length;
+    }
+
+    /// @notice The number of items in the IPFS data store
+    /// @return ipfs data array size
+    function ipfsDataCount() external view returns (uint256) {
+        return ipfsData.count;
     }
 
     /// @notice Updates the additional token properties associated with the metadata.

--- a/src/token/metadata/storage/MetadataRendererStorageV1.sol
+++ b/src/token/metadata/storage/MetadataRendererStorageV1.sol
@@ -16,6 +16,8 @@ contract MetadataRendererStorageV1 is MetadataRendererTypesV1 {
     /// @notice The IPFS data of all property items
     IPFSGroup[] public ipfsData;
 
-    /// @notice The attributes generated for a token
+    /// @notice The attributes generated for a token - mapping of tokenID uint16 array
+    /// @dev Array of size 16 1st element [0] used for number of attributes chosen, next N elements for those selections
+    /// @dev token ID
     mapping(uint256 => uint16[16]) public attributes;
 }

--- a/src/token/metadata/storage/MetadataRendererStorageV1.sol
+++ b/src/token/metadata/storage/MetadataRendererStorageV1.sol
@@ -8,14 +8,14 @@ import { MetadataRendererTypesV1 } from "../types/MetadataRendererTypesV1.sol";
 /// @notice The Metadata Renderer storage contract
 contract MetadataRendererStorageV1 is MetadataRendererTypesV1 {
     /// @notice The metadata renderer settings
-    Settings internal settings;
+    Settings public settings;
 
     /// @notice The properties chosen from upon generation
-    Property[] internal properties;
+    Property[] public properties;
 
     /// @notice The IPFS data of all property items
-    IPFSGroup[] internal ipfsData;
+    IPFSGroup[] public ipfsData;
 
     /// @notice The attributes generated for a token
-    mapping(uint256 => uint16[16]) internal attributes;
+    mapping(uint256 => uint16[16]) public attributes;
 }


### PR DESCRIPTION
Currently it's difficult to read what metadata is available on-chain and for debugging and token previews.

TODO: Add tests
