### PR TITLE
Add fee manager

### DIFF
--- a/script/DeployContracts.s.sol
+++ b/script/DeployContracts.s.sol
@@ -5,6 +5,7 @@ import "forge-std/Script.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { IManager, Manager } from "../src/manager/Manager.sol";
+import { BuilderFeeManager } from "../src/fees/BuilderFeeManager.sol";
 import { IToken, Token } from "../src/token/Token.sol";
 import { MetadataRenderer } from "../src/token/metadata/MetadataRenderer.sol";
 import { IAuction, Auction } from "../src/auction/Auction.sol";
@@ -48,8 +49,10 @@ contract DeployContracts is Script {
         // Deploy metadata renderer implementation
         address metadataRendererImpl = address(new MetadataRenderer(address(manager)));
 
+        address feeManager = address(new BuilderFeeManager(0, address(0)));
+
         // Deploy auction house implementation
-        address auctionImpl = address(new Auction(address(manager), weth));
+        address auctionImpl = address(new Auction(address(manager), feeManager, weth));
 
         // Deploy treasury implementation
         address treasuryImpl = address(new Treasury(address(manager)));

--- a/script/DeployVersion1_1.s.sol
+++ b/script/DeployVersion1_1.s.sol
@@ -6,6 +6,7 @@ import "forge-std/console2.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 
 import { IManager, Manager } from "../src/manager/Manager.sol";
+import { BuilderFeeManager } from "../src/fees/BuilderFeeManager.sol";
 import { IToken, Token } from "../src/token/Token.sol";
 import { MetadataRenderer } from "../src/token/metadata/MetadataRenderer.sol";
 import { IAuction, Auction } from "../src/auction/Auction.sol";
@@ -49,8 +50,10 @@ contract DeployVersion1_1 is Script {
         // Get root manager implementation + proxy
         Manager manager = Manager(managerProxy);
 
+        address feeManager = address(new BuilderFeeManager(0, address(0)));
+
         // Deploy auction upgrade implementation
-        address auctionUpgradeImpl = address(new Auction(managerProxy, weth));
+        address auctionUpgradeImpl = address(new Auction(managerProxy, feeManager, weth));
         // Deploy governor upgrade implementation
         address governorUpgradeImpl = address(new Governor(managerProxy));
         // Deploy treasury upgrade implementation

--- a/src/auction/Auction.sol
+++ b/src/auction/Auction.sol
@@ -50,7 +50,11 @@ contract Auction is IAuction, VersionedContract, UUPS, Ownable, ReentrancyGuard,
     /// @param _builderFeeManager The builder fee manager address
     /// @param _manager The contract upgrade manager address
     /// @param _weth The address of WETH
-    constructor(address _manager, address _builderFeeManager, address _weth) payable initializer {
+    constructor(
+        address _manager,
+        address _builderFeeManager,
+        address _weth
+    ) payable initializer {
         manager = IManager(_manager);
         builderFeeManager = _builderFeeManager;
         WETH = _weth;
@@ -389,7 +393,7 @@ contract Auction is IAuction, VersionedContract, UUPS, Ownable, ReentrancyGuard,
     /// @dev Gets the builder fee for amount of withdraw
     /// @param amount amount of funds to get fee for
     function _builderFeeForAmount(uint256 amount) private returns (address payable, uint256) {
-        (address payable recipient, uint256 bps) = IBuilderFeeManager(builderFeeManager).getBuilderFeesBPS(address(this));
+        (address payable recipient, uint256 bps) = IBuilderFeeManager(builderFeeManager).getBuilderFeesBPS();
         return (recipient, (amount * bps) / 10_000);
     }
 

--- a/src/fees/BuilderFeeManager.sol
+++ b/src/fees/BuilderFeeManager.sol
@@ -5,10 +5,8 @@ import { IBuilderFeeManager } from "./interfaces/IBuilderFeeManager.sol";
 import { Ownable } from "../lib/utils/Ownable.sol";
 
 contract BuilderFeeManager is Ownable, IBuilderFeeManager {
-    mapping(address => uint256) private feeOverride;
     uint256 private defaultFeeBPS;
 
-    event FeeOverrideSet(address indexed, uint256 indexed);
     event DefaultFeeSet(uint256 indexed);
 
     constructor(uint256 _defaultFeeBPS, address feeManagerAdmin) {
@@ -22,16 +20,7 @@ contract BuilderFeeManager is Ownable, IBuilderFeeManager {
         emit DefaultFeeSet(amountBPS);
     }
 
-    function setFeeOverride(address tokenContract, uint256 amountBPS) external onlyOwner {
-        require(amountBPS < 2001, "Fee too high (not greater than 20%)");
-        feeOverride[tokenContract] = amountBPS;
-        emit FeeOverrideSet(tokenContract, amountBPS);
-    }
-
-    function getBuilderFeesBPS(address mediaContract) external view returns (address payable, uint256) {
-        if (feeOverride[mediaContract] > 0) {
-            return (payable(owner()), feeOverride[mediaContract]);
-        }
+    function getBuilderFeesBPS() external view returns (address payable, uint256) {
         return (payable(owner()), defaultFeeBPS);
     }
 }

--- a/src/fees/BuilderFeeManager.sol
+++ b/src/fees/BuilderFeeManager.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import { IBuilderFeeManager } from "./interfaces/IBuilderFeeManager.sol";
+import { Ownable } from "../lib/utils/Ownable.sol";
+
+contract BuilderFeeManager is Ownable, IBuilderFeeManager {
+    mapping(address => uint256) private feeOverride;
+    uint256 private defaultFeeBPS;
+
+    event FeeOverrideSet(address indexed, uint256 indexed);
+    event DefaultFeeSet(uint256 indexed);
+
+    constructor(uint256 _defaultFeeBPS, address feeManagerAdmin) {
+        defaultFeeBPS = _defaultFeeBPS;
+        _transferOwnership(feeManagerAdmin);
+    }
+
+    function setDefaultFee(uint256 amountBPS) external onlyOwner {
+        require(amountBPS < 2001, "Fee too high (not greater than 20%)");
+        defaultFeeBPS = amountBPS;
+        emit DefaultFeeSet(amountBPS);
+    }
+
+    function setFeeOverride(address tokenContract, uint256 amountBPS) external onlyOwner {
+        require(amountBPS < 2001, "Fee too high (not greater than 20%)");
+        feeOverride[tokenContract] = amountBPS;
+        emit FeeOverrideSet(tokenContract, amountBPS);
+    }
+
+    function getBuilderFeesBPS(address mediaContract) external view returns (address payable, uint256) {
+        if (feeOverride[mediaContract] > 0) {
+            return (payable(owner()), feeOverride[mediaContract]);
+        }
+        return (payable(owner()), defaultFeeBPS);
+    }
+}

--- a/src/fees/interfaces/IBuilderFeeManager.sol
+++ b/src/fees/interfaces/IBuilderFeeManager.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+interface IBuilderFeeManager {
+    function getBuilderFeesBPS(address sender) external returns (address payable, uint256);
+}

--- a/src/fees/interfaces/IBuilderFeeManager.sol
+++ b/src/fees/interfaces/IBuilderFeeManager.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.10;
 
 interface IBuilderFeeManager {
-    function getBuilderFeesBPS(address sender) external returns (address payable, uint256);
+    function getBuilderFeesBPS() external returns (address payable, uint256);
 }

--- a/test/utils/NounsBuilderTest.sol
+++ b/test/utils/NounsBuilderTest.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.16;
 import { Test } from "forge-std/Test.sol";
 
 import { IManager, Manager } from "../../src/manager/Manager.sol";
+import { BuilderFeeManager } from "../../src/fees/BuilderFeeManager.sol";
 import { IToken, Token } from "../../src/token/Token.sol";
 import { IBaseMetadata, MetadataRenderer } from "../../src/token/metadata/MetadataRenderer.sol";
 import { IAuction, Auction } from "../../src/auction/Auction.sol";
@@ -25,6 +26,7 @@ contract NounsBuilderTest is Test {
 
     address internal managerImpl0;
     address internal managerImpl;
+    address internal feeManager;
     address internal tokenImpl;
     address internal metadataRendererImpl;
     address internal auctionImpl;
@@ -60,10 +62,11 @@ contract NounsBuilderTest is Test {
 
         managerImpl0 = address(new Manager());
         manager = Manager(address(new ERC1967Proxy(managerImpl0, abi.encodeWithSignature("initialize(address)", zoraDAO))));
+        feeManager = address(new BuilderFeeManager(0, address(0)));
 
         tokenImpl = address(new Token(address(manager)));
         metadataRendererImpl = address(new MetadataRenderer(address(manager)));
-        auctionImpl = address(new Auction(address(manager), weth));
+        auctionImpl = address(new Auction(address(manager), feeManager, weth));
         treasuryImpl = address(new Treasury(address(manager)));
         governorImpl = address(new Governor(address(manager)));
 


### PR DESCRIPTION
code review:
- is the fee override necessary
- address zero is checked in the auction contract because we want to give the option to leave the fee manager unset for certain deployments of the auction contract ie keep L1 feeless while applying fees on L2. is there a better way to implement this?