### PR TITLE
Add batch delegate with sig ERC1271

### DIFF
--- a/src/lib/interfaces/IERC1271.sol
+++ b/src/lib/interfaces/IERC1271.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (interfaces/IERC1271.sol)
+
+pragma solidity ^0.8.0;
+
+/**
+ * @dev Interface of the ERC1271 standard signature validation method for
+ * contracts as defined in https://eips.ethereum.org/EIPS/eip-1271[ERC-1271].
+ *
+ * _Available since v4.1._
+ */
+interface IERC1271 {
+    /**
+     * @dev Should return whether the signature provided is valid for the provided data
+     * @param hash      Hash of the data to be signed
+     * @param signature Signature byte array associated with _data
+     */
+    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+}

--- a/src/lib/token/ERC721Votes.sol
+++ b/src/lib/token/ERC721Votes.sol
@@ -185,7 +185,14 @@ abstract contract ERC721Votes is IERC721Votes, EIP712, ERC721 {
     /// @param _v The 129th byte and chain id of the signature
     /// @param _r The first 64 bytes of the signature
     /// @param _s Bytes 64-128 of the signature
-    function delegateBySig(address _from, address _to, uint256 _deadline, uint8 _v, bytes32 _r, bytes32 _s) external {
+    function delegateBySig(
+        address _from,
+        address _to,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external {
         // Ensure the signature has not expired
         if (block.timestamp > _deadline) revert EXPIRED_SIGNATURE();
 
@@ -293,7 +300,11 @@ abstract contract ERC721Votes is IERC721Votes, EIP712, ERC721 {
     /// @param _from The address delegating votes from
     /// @param _to The address delegating votes to
     /// @param _amount The number of votes delegating
-    function _moveDelegateVotes(address _from, address _to, uint256 _amount) internal {
+    function _moveDelegateVotes(
+        address _from,
+        address _to,
+        uint256 _amount
+    ) internal {
         unchecked {
             // If voting weight is being transferred:
             if (_from != _to && _amount > 0) {
@@ -402,7 +413,11 @@ abstract contract ERC721Votes is IERC721Votes, EIP712, ERC721 {
     /// @param _from The token sender
     /// @param _to The token recipient
     /// @param _tokenId The ERC-721 token id
-    function _afterTokenTransfer(address _from, address _to, uint256 _tokenId) internal override {
+    function _afterTokenTransfer(
+        address _from,
+        address _to,
+        uint256 _tokenId
+    ) internal override {
         // Transfer 1 vote from the sender to the recipient
         _moveDelegateVotes(delegates(_from), delegates(_to), 1);
 

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -40,7 +40,11 @@ contract TokenTest is NounsBuilderTest, TokenTypesV1 {
     }
 
     /// Test that the percentages for founders all ends up as expected
-    function test_FounderShareAllocationFuzz(uint256 f1Percentage, uint256 f2Percentage, uint256 f3Percentage) public {
+    function test_FounderShareAllocationFuzz(
+        uint256 f1Percentage,
+        uint256 f2Percentage,
+        uint256 f3Percentage
+    ) public {
         address f1Wallet = address(0x1);
         address f2Wallet = address(0x2);
         address f3Wallet = address(0x3);
@@ -434,7 +438,11 @@ contract TokenTest is NounsBuilderTest, TokenTypesV1 {
         assertEq(token.ownerOf(tokenId), newMinter);
     }
 
-    function testRevert_OnlyMinterCanMintToRecipient(address newMinter, address nonMinter, address recipient) public {
+    function testRevert_OnlyMinterCanMintToRecipient(
+        address newMinter,
+        address nonMinter,
+        address recipient
+    ) public {
         vm.assume(
             newMinter != nonMinter && newMinter != founder && newMinter != address(0) && newMinter != address(auction) && recipient != address(0)
         );
@@ -454,7 +462,12 @@ contract TokenTest is NounsBuilderTest, TokenTypesV1 {
         assertEq(token.ownerOf(tokenId), recipient);
     }
 
-    function testRevert_OnlyMinterCanMintBatch(address newMinter, address nonMinter, address recipient, uint256 amount) public {
+    function testRevert_OnlyMinterCanMintBatch(
+        address newMinter,
+        address nonMinter,
+        address recipient,
+        uint256 amount
+    ) public {
         vm.assume(
             newMinter != nonMinter &&
                 newMinter != founder &&
@@ -623,7 +636,11 @@ contract TokenTest is NounsBuilderTest, TokenTypesV1 {
         assertEq(token.getFounders().length, 1);
     }
 
-    function test_UpdateFounderShareAllocationFuzz(uint256 f1Percentage, uint256 f2Percentage, uint256 f3Percentage) public {
+    function test_UpdateFounderShareAllocationFuzz(
+        uint256 f1Percentage,
+        uint256 f2Percentage,
+        uint256 f3Percentage
+    ) public {
         deployMock();
 
         address f1Wallet = address(0x1);

--- a/test/utils/mocks/MockERC1271.sol
+++ b/test/utils/mocks/MockERC1271.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.16;
+
+import { IERC1271 } from "../../../src/lib/interfaces/IERC1271.sol";
+import { SignatureChecker } from "@openzeppelin/contracts/utils/cryptography/SignatureChecker.sol";
+
+contract MockERC1271 is IERC1271 {
+    address owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+
+    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue) {
+        bool isValid = SignatureChecker.isValidSignatureNow(owner, hash, signature);
+
+        if (isValid) {
+            return IERC1271.isValidSignature.selector;
+        }
+
+        return "";
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
Updates ERC721 votes to allow for batch ERC1271 delegate with sig. Will be used to improve delegation UX for collection plus: https://hackmd.io/eFSgnXefSUujGr75EqPCCg
- adds `batchDelegateBySigERC1271` to allow users to delegate tokens from multiple ERC1271 accounts
- adds `getBatchDelegateBySigTypedDataHash` to easily compute typehash for tests and clients 

Code review:
- Is the batch signature safe to use here?