### PR TITLE
Fix issue where rewards are incorrectly rounded

### DIFF
--- a/src/auction/Auction.sol
+++ b/src/auction/Auction.sol
@@ -478,9 +478,6 @@ contract Auction is IAuction, VersionedContract, UUPS, Ownable, ReentrancyGuard,
             revert INVALID_REWARD_TOTAL();
         }
 
-        // Calulate total rewards
-        split.totalRewards = (_finalBidAmount * totalBPS) / BPS_PER_100_PERCENT;
-
         // Check if founder reward is enabled
         bool hasFounderReward = _founderRewardBps > 0 && founderReward.recipient != address(0);
 
@@ -493,17 +490,23 @@ contract Auction is IAuction, VersionedContract, UUPS, Ownable, ReentrancyGuard,
         split.reasons = new bytes4[](arraySize);
 
         // Set builder reward
+        uint256 builderAmount = (_finalBidAmount * builderRewardsBPS) / BPS_PER_100_PERCENT;
         split.recipients[0] = builderRecipient;
-        split.amounts[0] = (_finalBidAmount * builderRewardsBPS) / BPS_PER_100_PERCENT;
+        split.amounts[0] = builderAmount;
+        split.totalRewards += builderAmount;
 
         // Set referral reward
+        uint256 referralAmount = (_finalBidAmount * referralRewardsBPS) / BPS_PER_100_PERCENT;
         split.recipients[1] = _currentBidRefferal != address(0) ? _currentBidRefferal : builderRecipient;
-        split.amounts[1] = (_finalBidAmount * referralRewardsBPS) / BPS_PER_100_PERCENT;
+        split.amounts[1] = referralAmount;
+        split.totalRewards += referralAmount;
 
         // Set founder reward if enabled
         if (hasFounderReward) {
+            uint256 founderAmount = (_finalBidAmount * _founderRewardBps) / BPS_PER_100_PERCENT;
             split.recipients[2] = founderReward.recipient;
-            split.amounts[2] = (_finalBidAmount * _founderRewardBps) / BPS_PER_100_PERCENT;
+            split.amounts[2] = founderAmount;
+            split.totalRewards += founderAmount;
         }
     }
 

--- a/test/Auction.t.sol
+++ b/test/Auction.t.sol
@@ -761,4 +761,37 @@ contract AuctionTest is NounsBuilderTest {
         assertEq(MockProtocolRewards(rewards).balanceOf(referral), 0.04 ether);
         assertEq(MockProtocolRewards(rewards).balanceOf(founder), 0.05 ether);
     }
+
+    function test_FounderBuilderAndReferralRewardWithSmallAmount() external {
+        // Setup
+        deployAltMock(founder, 500);
+
+        vm.prank(manager.owner());
+        manager.registerUpgrade(auctionImpl, address(rewardImpl));
+
+        vm.prank(auction.owner());
+        auction.upgradeTo(address(rewardImpl));
+
+        vm.prank(founder);
+        auction.unpause();
+
+        // Check reward values
+
+        vm.prank(bidder1);
+        auction.createBidWithReferral{ value: 1 ether + 19 }(2, referral);
+
+        vm.warp(10 minutes + 1 seconds);
+
+        auction.settleCurrentAndCreateNewAuction();
+
+        assertEq(token.ownerOf(2), bidder1);
+        assertEq(token.getVotes(bidder1), 1);
+
+        assertEq(address(treasury).balance, 0.88 ether + 19);
+        assertEq(address(rewards).balance, 0.03 ether + 0.04 ether + 0.05 ether);
+
+        assertEq(MockProtocolRewards(rewards).balanceOf(zoraDAO), 0.03 ether);
+        assertEq(MockProtocolRewards(rewards).balanceOf(referral), 0.04 ether);
+        assertEq(MockProtocolRewards(rewards).balanceOf(founder), 0.05 ether);
+    }
 }


### PR DESCRIPTION
Fixes an issue where bids could be constructed to permanently brick auction contracts due to rounding error in the `_computeTotalRewards` function