### PR TITLE
Fix DOS vector for auctions

### DIFF
--- a/src/auction/Auction.sol
+++ b/src/auction/Auction.sol
@@ -321,10 +321,16 @@ contract Auction is IAuction, VersionedContract, UUPS, Ownable, ReentrancyGuard,
 
             emit AuctionCreated(tokenId, startTime, endTime);
             return true;
-        } catch {
-            // Pause the contract if token minting failed
-            _pause();
-            return false;
+        } catch (bytes memory err) {
+            //keccak256(err) != keccak256(new bytes(0)))
+            if ((keccak256(err) != bytes32(0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470))) {
+                // Pause the contract if token minting failed with an error
+                _pause();
+                return false;
+            } else {
+                // Assume an out of gas error has occurred and DONT pause the contract
+                revert CANNOT_CREATE_AUCTION();
+            }
         }
     }
 

--- a/src/auction/IAuction.sol
+++ b/src/auction/IAuction.sol
@@ -103,6 +103,9 @@ interface IAuction is IUUPS, IOwnable, IPausable {
     /// @dev Thrown if the rewards total is greater than 100%
     error INVALID_REWARD_TOTAL();
 
+    /// @dev Thrown if a new auction cannot be created
+    error CANNOT_CREATE_AUCTION();
+
     ///                                                          ///
     ///                          STRUCTS                         ///
     ///                                                          ///

--- a/test/utils/mocks/MockERC721.sol
+++ b/test/utils/mocks/MockERC721.sol
@@ -5,15 +5,21 @@ import { ERC721 } from "../../../src/lib/token/ERC721.sol";
 import { UUPS } from "../../../src/lib/proxy/UUPS.sol";
 
 contract MockERC721 is UUPS, ERC721 {
+    error NotImplemented();
+
     constructor() initializer {
         __ERC721_init("Mock NFT", "MOCK");
+    }
+
+    function mint() public pure {
+        revert NotImplemented();
     }
 
     function mint(address _to, uint256 _tokenId) public {
         _mint(_to, _tokenId);
     }
 
-    function _authorizeUpgrade(address) internal override virtual {
+    function _authorizeUpgrade(address) internal virtual override {
         // no-op
     }
 }

--- a/test/utils/mocks/MockPartialTokenImpl.sol
+++ b/test/utils/mocks/MockPartialTokenImpl.sol
@@ -1,8 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.16;
 
-import {MockImpl} from "./MockImpl.sol";
+import { MockImpl } from "./MockImpl.sol";
 
 contract MockPartialTokenImpl is MockImpl {
+    error NotImplemented();
+
     function onFirstAuctionStarted() external {}
+
+    function mint() external pure {
+        revert NotImplemented();
+    }
 }


### PR DESCRIPTION
Fixes an issue where auctions could be DOSed by sending a very specific amount of gas triggering an out of gas error and pausing the contracts.